### PR TITLE
[chore] Remove DeleteResourceIfExists in favor of WithIgnoreNotFound and WithWaitForDeletion

### DIFF
--- a/tests/e2e/cleanup_test.go
+++ b/tests/e2e/cleanup_test.go
@@ -15,7 +15,10 @@ import (
 // cleanupResource logs and deletes the specified resource if it exists.
 func cleanupResource(t *testing.T, tc *TestContext, kind schema.GroupVersionKind, name types.NamespacedName, label string) { //nolint:thelper
 	t.Logf("Cleaning up %s if present", label)
-	tc.DeleteResourceIfExists(WithMinimalObject(kind, name))
+	tc.DeleteResource(
+		WithMinimalObject(kind, name),
+		WithWaitForDeletion(true),
+	)
 }
 
 // cleanupListResources deletes a list of resources of a given kind.

--- a/tests/e2e/cleanup_test.go
+++ b/tests/e2e/cleanup_test.go
@@ -4,9 +4,34 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 )
+
+// cleanupResource logs and deletes the specified resource if it exists.
+func cleanupResource(t *testing.T, tc *TestContext, kind schema.GroupVersionKind, name types.NamespacedName, label string) { //nolint:thelper
+	t.Logf("Cleaning up %s if present", label)
+	tc.DeleteResourceIfExists(WithMinimalObject(kind, name))
+}
+
+// cleanupListResources deletes a list of resources of a given kind.
+func cleanupListResources(t *testing.T, tc *TestContext, kind schema.GroupVersionKind, label string) { //nolint:thelper
+	list := tc.FetchResources(
+		WithMinimalObject(kind, types.NamespacedName{}),
+		WithListOptions(&client.ListOptions{}),
+	)
+
+	if len(list) > 0 {
+		t.Logf("Detected %d %s(s), deleting", len(list), label)
+		for _, res := range list {
+			cleanupResource(t, tc, kind, types.NamespacedName{Name: res.GetName()}, label)
+		}
+	}
+}
 
 // CleanupAllResources handles the cleanup of all resources (DSC, DSCI, etc.)
 func CleanupAllResources(t *testing.T) {
@@ -16,11 +41,26 @@ func CleanupAllResources(t *testing.T) {
 	tc, err := NewTestContext(t)
 	require.NoError(t, err, "Failed to initialize test context")
 
-	// Cleanup DataScienceCluster
-	t.Log("Cleaning up DataScienceCluster")
-	tc.DeleteResourceIfExists(WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName))
+	// Cleanup DataScienceCluster and DSCInitialization
+	cleanupResource(t, tc, gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName, "DataScienceCluster")
+	cleanupResource(t, tc, gvk.DSCInitialization, tc.DSCInitializationNamespacedName, "DSCInitialization")
+}
 
-	// Cleanup DSCInitialization
-	t.Log("Cleaning up DSCInitialization")
-	tc.DeleteResourceIfExists(WithMinimalObject(gvk.DSCInitialization, tc.DSCInitializationNamespacedName))
+// CleanupDefaultResources handles the cleanup of default resources: DSC, DSCI, and AuthConfig.
+func CleanupDefaultResources(t *testing.T) {
+	t.Helper()
+
+	// Initialize the test context.
+	tc, err := NewTestContext(t)
+	require.NoError(t, err, "Failed to initialize test context")
+
+	// Cleanup existing DataScienceCluster and DSCInitialization.
+	cleanupListResources(t, tc, gvk.DataScienceCluster, "DataScienceCluster")
+	cleanupListResources(t, tc, gvk.DSCInitialization, "DSCInitialization")
+
+	// Cleanup AuthConfig
+	cleanupResource(t, tc, gvk.Auth, types.NamespacedName{
+		Name:      serviceApi.AuthInstanceName,
+		Namespace: tc.AppsNamespace,
+	}, "AuthConfig")
 }

--- a/tests/e2e/components_test.go
+++ b/tests/e2e/components_test.go
@@ -310,10 +310,8 @@ func (tc *ComponentTestCtx) ValidateCRDRemoval(name string) {
 			&client.DeleteOptions{
 				PropagationPolicy: &propagationPolicy,
 			}),
+		WithWaitForDeletion(true),
 	)
-
-	// Ensure the CRD is removed
-	tc.EnsureResourceGone(WithMinimalObject(gvk.CustomResourceDefinition, nn))
 }
 
 // ValidateCRDReinstatement ensures that the CRD is properly reinstated when the component is enabled.

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -235,6 +235,9 @@ func TestOdhOperator(t *testing.T) {
 
 	log.SetLogger(zap.New(zap.UseDevMode(true)))
 
+	// Removing any existing default DSC, DSCI, and Auth CRs before starting the tests.
+	CleanupDefaultResources(t)
+
 	if testOpts.operatorControllerTest {
 		// individual test suites after the operator is running
 		mustRun(t, "ODH Manager E2E Tests", odhOperatorTestSuite)

--- a/tests/e2e/kserve_test.go
+++ b/tests/e2e/kserve_test.go
@@ -313,7 +313,10 @@ func (tc *KserveTestCtx) cleanExistingKnativeServing(t *testing.T) {
 		tc.g.Expect(err).NotTo(HaveOccurred(), "error marshalling Knative Serving object: %w", err)
 
 		t.Logf("Deleting Knative Serving %s in namespace %s: %s", obj.GetName(), obj.GetNamespace(), string(data))
-		tc.DeleteResourceIfExists(WithMinimalObject(gvk.KnativeServing, types.NamespacedName{Namespace: knativeServingNamespace, Name: obj.GetName()}))
+		tc.DeleteResource(
+			WithMinimalObject(gvk.KnativeServing, types.NamespacedName{Namespace: knativeServingNamespace, Name: obj.GetName()}),
+			WithWaitForDeletion(true),
+		)
 
 		// We also need to restart the Operator Pod.
 		operatorDeployment := "opendatahub-operator-controller-manager"

--- a/tests/e2e/kueue_test.go
+++ b/tests/e2e/kueue_test.go
@@ -140,6 +140,7 @@ func (tc *KueueTestCtx) ValidateKueuePreCheck(t *testing.T) {
 			&client.DeleteOptions{
 				PropagationPolicy: &propagationPolicy,
 			}),
+		WithWaitForDeletion(true),
 	)
 	tc.DeleteResource(
 		WithMinimalObject(gvk.CustomResourceDefinition, types.NamespacedName{Name: mkConfig}),
@@ -147,6 +148,7 @@ func (tc *KueueTestCtx) ValidateKueuePreCheck(t *testing.T) {
 			&client.DeleteOptions{
 				PropagationPolicy: &propagationPolicy,
 			}),
+		WithWaitForDeletion(true),
 	)
 
 	// Verify the DataScienceCluster become "Ready"
@@ -166,10 +168,8 @@ func (tc *KueueTestCtx) deleteAndValidateCRD(crdName string) {
 			&client.DeleteOptions{
 				PropagationPolicy: &propagationPolicy,
 			}),
+		WithWaitForDeletion(true),
 	)
-
-	// Verify the CRD is deleted
-	tc.EnsureResourceGone(WithMinimalObject(gvk.CustomResourceDefinition, types.NamespacedName{Name: crdName}))
 }
 
 // createMockCRD creates a mock CRD for a given group, version, kind, and namespace.

--- a/tests/e2e/resource_options_test.go
+++ b/tests/e2e/resource_options_test.go
@@ -75,6 +75,14 @@ type ResourceOptions struct {
 	// The ResourceID is used to provide a unique identifier for the resource, which is especially useful
 	// when working with multiple resources of the same type.
 	ResourceID string
+
+	// IgnoreNotFound determines whether to ignore "not found" errors during operations.
+	// Useful in scenarios where the resource may not exist and that's considered acceptable (e.g., optional cleanup).
+	IgnoreNotFound bool
+
+	// WaitForDeletion determines whether to wait for the resource to be fully deleted from the cluster.
+	// If true, the DeleteResource function will block until the resource is confirmed to be gone.
+	WaitForDeletion bool
 }
 
 // ResourceOpts is a function type used to configure options for the ResourceOptions object.
@@ -148,11 +156,27 @@ func WithListOptions(listOptions *client.ListOptions) ResourceOpts {
 	}
 }
 
+// WithIgnoreNotFound sets the IgnoreNotFound flag to true.
+// This allows operations to skip failures caused by missing resources.
+func WithIgnoreNotFound() ResourceOpts {
+	return func(ro *ResourceOptions) {
+		ro.IgnoreNotFound = true
+	}
+}
+
 // WithClientDeleteOptions creates a ResourceOpts function that sets the ClientDeleteOptions field
 // of the ResourceOptions. This will be used to configure the deletion behavior (e.g., propagation policy, grace period).
 func WithClientDeleteOptions(deleteOptions *client.DeleteOptions) ResourceOpts {
 	return func(ro *ResourceOptions) {
 		ro.ClientDeleteOptions = deleteOptions
+	}
+}
+
+// WithWaitForDeletion sets the WaitForDeletion flag to true.
+// When enabled, DeleteResource will wait until the resource is fully removed from the cluster.
+func WithWaitForDeletion() ResourceOpts {
+	return func(ro *ResourceOptions) {
+		ro.WaitForDeletion = true
 	}
 }
 

--- a/tests/e2e/resource_options_test.go
+++ b/tests/e2e/resource_options_test.go
@@ -156,11 +156,11 @@ func WithListOptions(listOptions *client.ListOptions) ResourceOpts {
 	}
 }
 
-// WithIgnoreNotFound sets the IgnoreNotFound flag to true.
-// This allows operations to skip failures caused by missing resources.
-func WithIgnoreNotFound() ResourceOpts {
+// WithIgnoreNotFound configures whether to skip the existence check and ignore errors if the resource is not found.
+// If set to true (default), the existence check is skipped, and missing resources will not cause errors.
+func WithIgnoreNotFound(ignore bool) ResourceOpts {
 	return func(ro *ResourceOptions) {
-		ro.IgnoreNotFound = true
+		ro.IgnoreNotFound = ignore
 	}
 }
 
@@ -172,11 +172,11 @@ func WithClientDeleteOptions(deleteOptions *client.DeleteOptions) ResourceOpts {
 	}
 }
 
-// WithWaitForDeletion sets the WaitForDeletion flag to true.
+// WithWaitForDeletion sets the WaitForDeletion flag.
 // When enabled, DeleteResource will wait until the resource is fully removed from the cluster.
-func WithWaitForDeletion() ResourceOpts {
+func WithWaitForDeletion(wait bool) ResourceOpts {
 	return func(ro *ResourceOptions) {
-		ro.WaitForDeletion = true
+		ro.WaitForDeletion = wait
 	}
 }
 

--- a/tests/e2e/test_context_test.go
+++ b/tests/e2e/test_context_test.go
@@ -627,30 +627,6 @@ func (tc *TestContext) DeleteResource(opts ...ResourceOpts) {
 	// Create a ResourceOptions object based on the provided opts.
 	ro := tc.NewResourceOptions(opts...)
 
-	tc.g.Eventually(func(g Gomega) {
-		// Optionally check existence unless IgnoreNotFound is set
-		if !ro.IgnoreNotFound {
-			u, err := fetchResource(ro)
-			g.Expect(err).NotTo(HaveOccurred(), "Failed to fetch %s instance %s before deletion", ro.GVK.Kind, ro.ResourceID)
-			g.Expect(u).NotTo(BeNil(), "Expected %s instance %s to exist before deletion", ro.GVK.Kind, ro.ResourceID)
-		}
-
-		// Perform the delete (client already handles IsNotFound gracefully)
-		tc.g.Delete(
-			ro.GVK,
-			ro.NN,
-			ro.ClientDeleteOptions,
-		).Eventually().Should(Succeed(), "Failed to delete %s instance %s", ro.GVK.Kind, ro.ResourceID)
-
-		// Optionally wait for deletion
-		if ro.WaitForDeletion {
-			// Ensure resource no longer exists
-			u, err := fetchResource(ro)
-			g.Expect(errors.IsNotFound(err)).To(BeTrue(), "Expected %s instance %s to be fully deleted", ro.GVK.Kind, ro.ResourceID)
-			g.Expect(u).To(BeNil(), "Expected %s instance %s to be nil after deletion", ro.GVK.Kind, ro.ResourceID)
-		}
-	}).Should(Succeed())
-
 	if !ro.IgnoreNotFound {
 		// Ensure the resource exists before attempting deletion
 		tc.EnsureResourceExists(
@@ -667,41 +643,9 @@ func (tc *TestContext) DeleteResource(opts ...ResourceOpts) {
 	).Eventually().Should(Succeed(), "Failed to delete %s instance %s", ro.GVK.Kind, ro.ResourceID)
 
 	if ro.WaitForDeletion {
-		tc.g.Eventually(func(g Gomega) {
-			_, err := fetchResource(ro)
-			g.Expect(errors.IsNotFound(err)).To(BeTrue(), "Expected %s instance %s to be fully deleted", ro.GVK.Kind, ro.ResourceID)
-		}).Should(Succeed(), "Resource %s instance %s was not fully deleted", ro.GVK.Kind, ro.ResourceID)
+		opts = append(opts, WithCustomErrorMsg("Resource %s instance %s was not fully deleted", ro.GVK.Kind, ro.ResourceID))
+		tc.EnsureResourceGone(opts...)
 	}
-}
-
-// DeleteResourceIfExists verifies whether a specific Kubernetes resource exists and deletes it if found.
-// If the resource exists, it is deleted using the provided client options. The test will succeed even if the resource
-// does not exist (i.e., the deletion is considered successful if the resource is not found).
-//
-// Parameters:
-//   - opts(...ResourceOpts): Optional options for configuring the resource and deletion behavior.
-func (tc *TestContext) DeleteResourceIfExists(opts ...ResourceOpts) {
-	// Create a ResourceOptions object based on the provided opts.
-	ro := tc.NewResourceOptions(opts...)
-
-	// Use ensureResourceExistsOrNil to attempt to fetch the resource with retries
-	_, err := tc.ensureResourceExistsOrNil(ro)
-
-	// If error is not nil and not IsNotFound, we fail the test.
-	if err != nil && !errors.IsNotFound(err) {
-		tc.g.Expect(err).NotTo(
-			HaveOccurred(),
-			"Unexpected error while checking existence of %s instance %s", ro.GVK.Kind, ro.ResourceID,
-		)
-		return
-	}
-
-	// Delete the resource
-	tc.g.Delete(
-		ro.GVK,
-		ro.NN,
-		ro.ClientDeleteOptions,
-	).Eventually().Should(Succeed(), "Failed to delete %s instance %s", ro.GVK.Kind, ro.ResourceID)
 }
 
 // FetchInstallPlanName retrieves the name of the InstallPlan associated with a subscription.

--- a/tests/e2e/trustyai_test.go
+++ b/tests/e2e/trustyai_test.go
@@ -119,6 +119,7 @@ func (tc *TrustyAITestCtx) DeleteInferenceServices(t *testing.T) {
 			&client.DeleteOptions{
 				PropagationPolicy: &propagationPolicy,
 			}),
+		WithWaitForDeletion(true),
 	)
 }
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
it aligns with the goals of that effort, focusing on the optimization and cleanup of the E2E test suite.

This PR includes the following changes:

1. **Removed `DeleteResourceIfExists`:**  
   The `DeleteResourceIfExists` function has been removed. It has been replaced with two new options:
    - `WithIgnoreNotFound`: This option allows skipping the existence check before deletion and will also skip errors if the resource is not found.
    - `WithWaitForDeletion`: This option allows waiting for the resource to be fully deleted, replacing the use of `EnsureResourceGone`.

2. **Updated `DeleteResource`:**  
   The current implementation of `DeleteResource` has been updated to include `WithWaitForDeletion` for cases where we were previously waiting for deletion using `EnsureResourceGone`. Now, the wait logic is more flexible and can be controlled through the `WithWaitForDeletion` flag.

## Changes made:
- Removed `DeleteResourceIfExists` function.
- Replaced `DeleteResourceIfExists` logic with `WithIgnoreNotFound` and `WithWaitForDeletion` in relevant parts of the codebase.
- Updated the `DeleteResource` function to support `WithWaitForDeletion` and refactored the logic to accommodate this change.
- Simplified resource deletion flow.

## Related Changes:
- Updated relevant tests to ensure compatibility with the new deletion flow.
- Added documentation updates for `WithIgnoreNotFound` and `WithWaitForDeletion` to clarify their usage.

<!--- Link your JIRA and related links here for reference. -->

## Alignment with [RHOAIENG-23354](https://issues.redhat.com/browse/RHOAIENG-23354):
These changes align with the goals and the ongoing effort of **[RHOAIENG-23354](https://issues.redhat.com/browse/RHOAIENG-23354)**, which focuses on the optimization and cleanup of the E2E test suite. By removing redundant functions and enhancing the flexibility of resource deletion, we aim to streamline the testing process, reduce code complexity, and improve maintainability.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- All tests that previously used `DeleteResourceIfExists` should now use `WithIgnoreNotFound` and `WithWaitForDeletion` appropriately.
- The updated deletion logic has been tested with the new options.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
